### PR TITLE
fix: make `include_logs` flag optional

### DIFF
--- a/src/client/tsunami-client-interface.ts
+++ b/src/client/tsunami-client-interface.ts
@@ -52,7 +52,7 @@ export interface TsunamiClient {
   ): AsyncGenerator<TsunamiTransaction, void, undefined>;
   getWalletTransactions(
     address: string,
-    criteria: GetWalletTransactionsQuery & { include_logs: true },
+    criteria: GetWalletTransactionsQuery & { include_logs?: true },
     boundaries: TsunamiDataQueryBoundaries,
   ): AsyncGenerator<TsunamiTransactionWithLogs, void, undefined>;
 }

--- a/src/dto/get-wallet-transactions-query.ts
+++ b/src/dto/get-wallet-transactions-query.ts
@@ -1,7 +1,7 @@
 import { TransferDirection } from '../enum/transfer-direction';
 
 export interface GetWalletTransactionsQuery {
-  include_logs: boolean;
+  include_logs?: boolean;
 
   direction?: TransferDirection;
 


### PR DESCRIPTION
I've made `include_logs` optional to de-bloat getWalletTransactions call